### PR TITLE
DE01 : Chiffrement ARGON2ID

### DIFF
--- a/ScriptsSQL/gsbfrais_structure.sql
+++ b/ScriptsSQL/gsbfrais_structure.sql
@@ -42,7 +42,7 @@ CREATE TABLE  Visiteur (
   nom char(30) DEFAULT NULL,
   prenom char(30)  DEFAULT NULL, 
   login char(20) DEFAULT NULL,
-  mdp char(20) DEFAULT NULL,
+  mdp char(100) DEFAULT NULL,
   adresse char(30) DEFAULT NULL,
   cp char(5) DEFAULT NULL,
   ville char(30) DEFAULT NULL,

--- a/hash_length.php
+++ b/hash_length.php
@@ -1,0 +1,5 @@
+<?php
+$longueur = strlen('$argon2i$v=19$m=65536,t=4,p=1$UkFiS0dTUGNXSEJQaFY3UQ$5i8BMEUqn+q0Y6kh9JqJhhqyXQSHSkcqvRWKHHr23z8');
+echo $longueur;
+// Donc la longueur d'un hash Argon2id est de 97 char 
+// On met 100 pour être sur 

--- a/hash_mdps_bdd.php
+++ b/hash_mdps_bdd.php
@@ -1,0 +1,27 @@
+<?php
+$bdd = new PDO(
+    'mysql:host=localhost;dbname=gsbfrais',
+    'userGsb',
+    'secret'
+);
+
+$requete = 'SELECT id, mdp from visiteur;';
+$reponse = $bdd -> query($requete);
+$mdps = $reponse -> fetchall(PDO::FETCH_ASSOC);
+
+foreach ($mdps as $ligne){
+    echo $ligne['mdp'] . PHP_EOL;
+    $id = $ligne['id'];
+    $hash = password_hash($ligne['mdp'], PASSWORD_ARGON2ID);
+    echo $hash . PHP_EOL;
+
+    $requete2 = 'UPDATE visiteur SET mdp = ? WHERE id = ?;';
+    $reponse2 = $bdd -> prepare($requete2);
+    $reponse2 -> execute([$hash, $id]);
+
+}
+
+
+
+
+?>

--- a/www/controleurs/c_connexion.php
+++ b/www/controleurs/c_connexion.php
@@ -1,4 +1,5 @@
 <?php
+
 $action = lireDonneeUrl('action', 'demandeConnexion');
 
 switch($action){
@@ -10,7 +11,11 @@ switch($action){
 	case 'valideConnexion':{
 		$login = lireDonneePost('login');
 		$mdp = lireDonneePost('mdp');
+		$hash = password_hash($mdp, PASSWORD_ARGON2ID);
 		$visiteur = $pdo->getInfosVisiteur($login,$mdp);
+
+		//faire une requete sql pour recuperer le hash?!?
+
 		if(!is_array( $visiteur)){
 			ajouterErreur("Login ou mot de passe incorrect", $tabErreurs);
 		  include("vues/v_debutContenu.php");
@@ -18,6 +23,7 @@ switch($action){
 			include("vues/v_connexion.php");
 		}
 		else{
+			//faire getinfosvisiteurs et connecter 
 			$id = $visiteur['id'];
 			$nom =  $visiteur['nom'];
 			$prenom = $visiteur['prenom'];

--- a/www/controleurs/c_connexion.php
+++ b/www/controleurs/c_connexion.php
@@ -11,19 +11,23 @@ switch($action){
 	case 'valideConnexion':{
 		$login = lireDonneePost('login');
 		$mdp = lireDonneePost('mdp');
+		// on calcule le hash du mdp avec ARGON2ID
 		$hash = password_hash($mdp, PASSWORD_ARGON2ID);
 		$visiteur = $pdo->getInfosVisiteur($login,$mdp);
 
-		//faire une requete sql pour recuperer le hash?!?
+		// maintenant, avec la requete sql de getInfosVisiteur(), on recupère le hash au lieu du mdp
 
-		if(!is_array( $visiteur)){
+
+		// Donc, on utilise la fonction password_verify() pour vérifier que le hash dans la base de données correspond au mdp entré dans le champ et récupéré par POST
+
+		if(!password_verify($mdp, $visiteur['mdp'])){ // !is_array($visiteur)
 			ajouterErreur("Login ou mot de passe incorrect", $tabErreurs);
-		  include("vues/v_debutContenu.php");
+		    include("vues/v_debutContenu.php");
 			include("vues/v_erreurs.php");
 			include("vues/v_connexion.php");
 		}
 		else{
-			//faire getinfosvisiteurs et connecter 
+			//récupère getinfosvisiteurs et se connecte 
 			$id = $visiteur['id'];
 			$nom =  $visiteur['nom'];
 			$prenom = $visiteur['prenom'];

--- a/www/include/class.pdogsb.inc.php
+++ b/www/include/class.pdogsb.inc.php
@@ -32,6 +32,7 @@ class PdoGsb {
 
     public function getHash($mdp){
         //récuperer lehash
+
     }
 
 
@@ -43,14 +44,18 @@ class PdoGsb {
    * @return array  l'id, le nom et le prénom sous la forme d'un tableau associatif 
   */
     public function getInfosVisiteur($login, $mdp){
-  	    $req = "select id, nom, prenom from Visiteur where login = ? and mdp = ?";
+  	    $req = "select id, nom, prenom, mdp from Visiteur where login = ?"; // and mdp = ?
+        // J'ai ajouté dans la requête le mdp, pour pouvoir récupérer le hash de la bdd et le comparer
   	    $cmd = $this->monPdo->prepare($req);
         $cmd->bindValue(1, $login);
-        $cmd->bindValue(2, $mdp);
+        // $cmd->bindValue(2, $mdp);
         $cmd->execute();
   	    $ligne = $cmd->fetch();
   	    return $ligne;
     } 
+
+
+    
   /**
    * Retourne sous forme d'un tableau associatif toutes les lignes de frais hors forfait
    * concernées par les deux arguments   

--- a/www/include/class.pdogsb.inc.php
+++ b/www/include/class.pdogsb.inc.php
@@ -28,6 +28,13 @@ class PdoGsb {
     public function _destruct(){
         $this->monPdo = null;
     }
+
+
+    public function getHash($mdp){
+        //récuperer lehash
+    }
+
+
   /**
    * Retourne les informations d'un visiteur
    


### PR DESCRIPTION
L'issue #3  (DE01) est réglée ! 
Les mdps ne sont plus stockés en clair. A la place, on stocke leur hash avec ARGON2ID dans la bdd.
J'ai modifié et documenté mon code. Entre autre, il a fallu modifier la requête SQL et le PDO, et la fonction getInfosVisiteur()

https://github.com/KeligRimpot/AppliFrais/issues/3#issuecomment-2049614096
